### PR TITLE
Corrected  kamon.metric key

### DIFF
--- a/introduction/project-info/migrating-from-0.3.x-and-0.2.x.md
+++ b/introduction/project-info/migrating-from-0.3.x-and-0.2.x.md
@@ -75,7 +75,7 @@ kamon.metrics {
 Should now look like this:
 
 {% code_block typesafeconfig %}
-kamon.metrics {
+kamon.metric {
   filters {
     akka-actor {
       includes = [ "system-name/user/simple-service-actor" ]


### PR DESCRIPTION
As of v 0.4.0 the kamon metrics section should be referenced as 'kamon.metric' and not as 'kamon.metrics'