### PR TITLE
Add note about time-units

### DIFF
--- a/website/documentation/0.6.x/kamon-datadog/overview.md
+++ b/website/documentation/0.6.x/kamon-datadog/overview.md
@@ -80,6 +80,9 @@ For example,
 kamon.datadog.time-units = "ms"
 ```
 will scale all timing measurements to milliseconds right before sending to datadog.
+Note that if timing measurements are below 1 millisecond when you set `time-units="ms"`,
+the measurements are reported to Datadog as zero values by dropping everything below the decimal point,
+because Kamon holds all timing measurements in `Long` internally.
 
 Integration Notes
 -----------------

--- a/website/documentation/0.6.x/kamon-statsd/overview.md
+++ b/website/documentation/0.6.x/kamon-statsd/overview.md
@@ -97,6 +97,10 @@ For example,
 kamon.statsd.time-units = "ms"
 ```
 will scale all timing measurements to milliseconds right before sending to StatsD.
+Note that if timing measurements are below 1 millisecond when you set `time-units="ms"`,
+the measurements are reported to StatsD as zero values by dropping everything below the decimal point,
+because Kamon holds all timing measurements in `Long` internally.
+
 
 Visualization and Fun
 ---------------------


### PR DESCRIPTION
Hi, does it make sense to add this?

Recently I started using Kamon with Datadog, which overall worked nicely. However, I struggled for days to find out why metrics kept showing zero values on Datadog sometimes. They turned out elapsed time measures below 1 millisecond, when `time-units="ms"`.

I think this note would save other people's time when the same thing happens..