### PR TITLE
Remove references to zipkin

### DIFF
--- a/website/documentation/1.x/reporters/jaeger.md
+++ b/website/documentation/1.x/reporters/jaeger.md
@@ -6,11 +6,9 @@ layout: documentation-1.x
 Sending Spans to Jaeger
 =======================
 
-[Jaeger][1] is distributed tracing system. It was originally created at Twitter but currently is run as a completely
-independent open source project. Most people would recognize Zipkin as _the_ distributed tracing platform since it has
-a really strong and active community and it is integrated with most major libraries and toolkits on the JVM.
+[Jaeger][1] is a distributed tracing system. It was originally created at Uber.
 
-The `kamon-zipkin` module translates Kamon's representation of Spans and sends them to Zipkin's v2 API.
+The `kamon-jaeger` module translates Kamon's representation of Spans and sends them to Jaeger's API.
 
 
 ### Installation and Startup


### PR DESCRIPTION
Looks like there was some bad copy/paste from the zipkin docs. I removed references to zipkin as a quick fix. Longer-term you may want to add some additional detail like it being influenced by zipkin etc.