### PR TITLE
Tiny fixes to the new documentation

### DIFF
--- a/website/documentation/1.x/core/advanced/metric-instruments.md
+++ b/website/documentation/1.x/core/advanced/metric-instruments.md
@@ -6,7 +6,7 @@ layout: documentation-1.x
 Metric Instruments
 ==================
 
-Kamon provides five different metric recording instruments on it's core metrics API. Each instrument might be slightly
+Kamon provides five different metric recording instruments in its core metrics API. Each instrument might be slightly
 different in implementation than what other metrics libraries offer so we recommend to take a bit of time to understand
 how each instrument works and how they might differ from what you have seen before.
 
@@ -31,10 +31,10 @@ Gauges are good for slow moving variables, like available memory and disk usage.
 
 ### Histograms
 
-Histograms track the entire value distribution of a given metric. When measuring value distributions (usually latency)
-it is hard to know upfront what information is important for you, is it the median? the average? (hell no!), the maximum?
+Histograms track the entire value distribution of a given metric. When measuring value distributions (like latency)
+it is hard to know upfront what information is important for you - is it the median? the average? (hell no!), the maximum?
 the standard deviation? percentiles? what percentiles? 95%? 98%? 99%? 99.99%?. Kamon doesn't take that decision for you,
-instead store **all measurements** taken from your application and let the reporting modules decide whats the best that
+instead it stores **all measurements** taken from your application and lets the reporting modules decide what's the best that
 can be done with the data.
 
 Some applications process millions of events per second, meaning that millions of measurements will be taken every
@@ -43,10 +43,10 @@ significant memory and CPU overhead? Yes, it is possible, thanks to the [HdrHist
 is what powers Kamon's histogram.
 
 The HdrHistogram mixes linear and exponential bucket systems to produce a unique data structure capable of recording
-measurements with configurable precision and fixed memory and cpu costs, regardless of the number of measurements
-recorded. Under the hood, the HdrHistogram stores all the data in a single array of longs as occurrences of a given value,
+measurements with configurable precision and fixed memory and CPU costs, regardless of the number of measurements
+recorded. Under the hood, the HdrHistogram stores all the data in a single array of `long`s as occurrences of a given value,
 adjusted with the precision configuration provided when creating the HdrHistogram. For example, if we were to store a
-recording of 10 units in a HdrHistogram with an underlying array similar to the one shown in the diagram bellow, all
+recording of 10 units in an HdrHistogram with an underlying array similar to the one shown in the diagram bellow, all
 that's needed is to add one to the value in the ninth bucket.
 
 <img class="img-fluid" src="/assets/img/diagrams/hdr-layout.png">
@@ -56,15 +56,14 @@ bucket corresponding to the value 20 is used. The actual number of buckets neces
 based on two values passed upon creation:
 
 * __number of significant value digits__: Gives you control over the precision with which values are recorded in the
-HdrHistogtram. If you create a HdrHistogram tracking values with three significant value digits of precision, then the
-required number of buckets is calculated to ensure that all recordings fall into buckets that are no longer than 0.1%
-away from the original recording value. Two significant value digits give you 1% precision and one significant value
+HdrHistogram. If you create a HdrHistogram tracking values with three significant value digits of precision, then the
+required number of buckets is calculated to ensure that all recordings fall into buckets that do not differ by more than 0.1% from the original value. Two significant value digits give you 1% precision and one significant value
 digit gives you 10% precision. Kamon always uses two significant value digits by default.
 
 * __maximum trackable value__: Gives you control over the range of values that can be covered by the HdrHistogram. Kamon
 uses 3.600.000.000.000 (one hour in nanoseconds) by default.
 
-The underlying data structure (the longs array) is allocated only once when the HdrHistogram is created and it is reused
+The underlying data structure (the array of `long`s) is allocated only once when the HdrHistogram is created and it is reused
 during the lifetime of the monitored entity.
 
 This is just a high level overview, we highly encourage you to read the documentation available in the [HdrHistogram]
@@ -73,23 +72,22 @@ site to get a better understanding of how it works.
 
 ### Timers
 
-A timer isn't much than a simple wrapper for a histogram, but with bit of extra API surface that allows you to `start()`
+A timer isn't much than a simple wrapper for a histogram, but with a bit of extra API surface that allows you to `start()`
 the timer and later `stop()` the `StartedTimer` instance that you get back. Timers produce a value distribution with all
 recorded latencies on every reporting period.
 
 
 ### Range Samplers
 
-Range samplers are a unusual type of instrument, only seen so far in Kamon. When monitoring queues, like we do for actor
-mailboxes, just having a number going up and down (like a traditional gauge) that is collected every X amount of time
-isn't enough. Many things can happen to a queue between recordings, you could get a million messages in a queue and
+Range samplers are an unusual type of instrument, only seen so far in Kamon. When monitoring queues, like we do for actor
+mailboxes, just having a number going up and down (like a traditional gauge) that is collected once at a reporting tick isn't enough. Many things can happen to a queue between recordings, such as you could get a million messages in a queue and
 process them all before the next recording, seeing a value of 0 that does not reflect the fact that the queue had a
 million elements just a few seconds ago.
 
 When monitoring a queue size it is not just about knowing where it is at a given moment because that number is probably
 incorrect right after reading it, but knowing where it **was** is of great help. The range sampler internally tracks three
 variables: the current value, the minimum and the maximum observed value. These three values are read and stored in a
-histogram every 100 milliseconds (by default) and produce a value distribution on each reporting interval.
+histogram every 200 milliseconds (by default) and produce a value distribution on each reporting interval.
 
 After each observation, the minimum and maximum tracking variables are reset to the current value, meaning that if no
 changes occur then the three of them will have the same value when the next observation happens.

--- a/website/documentation/1.x/core/basics/metrics.md
+++ b/website/documentation/1.x/core/basics/metrics.md
@@ -22,7 +22,7 @@ You can find more details in the [Metric Instruments][1] section.
 
 ### Creating and Removing Metrics
 
-To record metrics you need to request a appropriate instrument from the `Kamon` companion object (or static members, if
+To record metrics you need to request the appropriate instrument from the `Kamon` companion object (or static members, if
 on Java), optionally *refine* it with tags and then you are ready to record metrics. Let's look at a example:
 
 
@@ -30,28 +30,27 @@ on Java), optionally *refine* it with tags and then you are ready to record metr
 {%   language scala kamon-1.x/core-basics/src/main/scala/kamon/examples/scala/MetricBasics.scala tag:creating-metrics label:"Scala" %}
 {% endcode_example %}
 
-In the above code we are:
   1. Simple metrics that do not require tags can be looked up and used in one-liners. `(1)`
   2. Defining a metric with a counter instrument `(2)`
   3. Creating two "refined" (or tagged, if that helps to understand better) versions of the metric, one using the
-     "class=InvalidUser" `(3)` tag and another using the "class=InvalidPassword" tag `(4)`.
+     `class=InvalidUser` `(3)` tag and another using the `class=InvalidPassword` tag `(4)`.
   4. Incrementing one of the refined metrics `(5)`
-  5. Removing a specific instance of the `app.error` metric with the "class=InvalidUser" tag from Kamon. `(6)`
+  5. Removing a specific instance of the `app.error` metric with the `class=InvalidUser` tag from Kamon. `(6)`
 
 There are a few important things that you should keep in mind when using metrics:
   - When possible, define and refine your metrics up front, as a static member or instance members on the instrumented
-    components of your services, this saves a bit of time in looking up instruments. If you can't do so, rest assured
+    components of your services. This saves a bit of time in looking up instruments. If you can't do so, rest assured
     that Kamon will always return the same instrument instance if requested with the same arguments (metric name and tags)
     from anywhere in your code.
   - Always provide a measurement unit when your metric is tracking either time (milliseconds, microseconds, etc) or
     information (byes, kilobytes, etc). This will ensure that reporting modules can scale the recorded data appropriately.
   - Follow our metrics naming conventions: we use namespaced metric names that describe "what" is being measured and use
     tags to specify from "where" we are getting this information. For example, we use the `span.processing-time` metric
-    to track Span's latency and we add a `operation=login` or `operation=search` tag (plus some more) to identify from
+    to track Span latencies and we add an `operation=login` or `operation=search` tag (plus some more) to identify from
     where we are recording such measurements.
   - **Avoid high cardinality variables as metric tags** since they will most likely overwhelm your monitoring systems or make
     your bill go through the roof. Things like user identifiers, IP addresses, session identifiers and so on are a big
-    no no for metric tags.
+    *no no* for metric tags.
 
 
 
@@ -100,8 +99,7 @@ back a `StartedTimer` instance that can be `stop()`ed whenever the operation you
 #### Range Samplers
 
 A range sampler is always paired with a component or piece of state that starts at zero and can increment and decrement,
-like a message queue size or the number of concurrent requests being processed by a service. The exposed operations in
-a gauge are `increment()`, `increment(times)`, `decrement()` and `decrement(times)`.
+like a message queue size or the number of concurrent requests being processed by a service. The exposed operations are identical with those offered by gauges, namely `increment()`, `increment(times)`, `decrement()` and `decrement(times)`.
 
 
 {% code_example %}

--- a/website/documentation/1.x/core/basics/overview.md
+++ b/website/documentation/1.x/core/basics/overview.md
@@ -6,7 +6,7 @@ layout: documentation-1.x
 Overview
 ========
 
-Kamon is a instrumentation toolkit for applications running on the JVM. With Kamon you can record metrics, trace requests
+Kamon is an instrumentation toolkit for applications running on the JVM. With Kamon you can record metrics, trace requests
 and propagate context across distributed systems without locking your service to a specific metrics or tracing vendor.
 
 From a bird's eye view, Kamon can be decomposed in three main components: the core APIs for metrics, tracing and context
@@ -21,7 +21,7 @@ with Kamon's APIs and abstract you away from how and where the collected data wi
 The `kamon-core` project contains the basic building blocks upon which every other module is built and the only API
 surface that you need to understand and interact with if using Kamon directly (see automatic instrumentation). The core
 module can be divided into three main sections:
-  - The **Metrics API** provides several instrument types (counters, gauges, histrograms, timers and range samplers) with
+  - The **Metrics API** provides several instrument types (counters, gauges, histograms, timers and range samplers) with
     a dimensional data model for metrics recording.
   - The **Tracing API** allows to create, correlate and tag Spans that represent operations executed across distributed
     systems.
@@ -31,17 +31,17 @@ module can be divided into three main sections:
 
 ### Automatic Instrumentation
 
-There are a growing number of automatic instrumentation modules that hook into the internals of several widely used
-frameworks and libraries to bring metrics, traces and context propagation without needed to use the Core APIs directly.
+There exists a growing number of automatic instrumentation modules that hook into the internals of several widely used
+frameworks and libraries to bring metrics, traces and context propagation without the need to use the Core APIs directly.
 Some examples are:
-  - The `kamon-akka` and `kamon-akka-remote` modules provides actor, routers, dispatcher and actor groups metrics,
+  - The `kamon-akka` and `kamon-akka-remote` modules provides actor, router, dispatcher and actor group metrics,
     distributed message tracing and context propagation both locally and across a cluster.
   - The `kamon-akka-http` and `kamon-play` modules provide automatic context propagation and distributed tracing on both
     on the server and client sides of Akka HTTP and Play Framework, respectively.
   - The `kamon-jdbc` module hooks into all JDBC calls, creating Spans for each operation and tracking Hikari CP metrics
     when possible.
 
-When using these modules it is necessary for applications to run with the bytecode instrumentation agent.
+When using these modules it is necessary for applications to run with the [bytecode instrumentation agent][1].
 
 
 ### Reporters
@@ -50,7 +50,9 @@ Finally, the reporter modules send and/or expose all the collected data to sever
 types of reporting modules:
   - **Metric Reporters** get all the measurements recorded during each "tick" and expose/send this data to systems like
     Prometheus, JMX, Kamino, Datadog, etc.
-  - **Span Reporters** get batches of Spans to be sent to distributed tracing system like Zipkin, Jaeger and so on.
+  - **Span Reporters** get batches of Spans to be sent to distributed tracing systems like Zipkin, Jaeger and so on.
 
 Creating new reporters is just about implementing the appropriate interfaces and calling `Kamon.addReporter(...)` when
 starting your services.
+
+[1]: ../../recipes/adding-the-aspectj-weaver/


### PR DESCRIPTION
OMG I read documentation ;-)

Please keep an extra eye on the range sampler part:

> histogram every 100 milliseconds

Isn't it 200ms as defined in [`reference.conf`](https://github.com/kamon-io/Kamon/blob/e711bb0170f0939f9054cea76da0ce09005ccef3/kamon-core/src/main/resources/reference.conf#L76)?