### PR TITLE
Fix host/jvm config parameter names in the example

### DIFF
--- a/docs/latest/instrumentation/system-metrics.md
+++ b/docs/latest/instrumentation/system-metrics.md
@@ -26,11 +26,11 @@ By default the `kamon-system-metrics` module starts with Host and JVM metrics en
 {% code_block typesafeconfig %}
 kamon {
   system-metrics {
-   #sigar is enabled by default
-   sigar-enabled = true
+   # Host-level (via Sigar) metrics are enabled by default
+   host.enabled = true
 
-   #jmx related metrics are enabled by default
-   jmx-enabled = true
+   # JVM-level metrics are enabled by default
+   jvm.enabled = true
   }
 }
 {% endcode_block %}


### PR DESCRIPTION
Per what is in [`reference.conf`](https://github.com/kamon-io/kamon-system-metrics/blob/v1.0.1/src/main/resources/reference.conf#L8) in [kamon-system-metrics](https://github.com/kamon-io/kamon-system-metrics) 1.0.1.