### PR TITLE
Add configuration instructions to override New Relic metric and trace API endpoints

### DIFF
--- a/docs/latest/reporters/newrelic.md
+++ b/docs/latest/reporters/newrelic.md
@@ -21,6 +21,12 @@ kamon.newrelic {
     # A New Relic Insights API Insert Key is required to send trace data to New Relic
     # https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#insert-key-create
     nr-insights-insert-key = ${?INSIGHTS_INSERT_KEY}
+
+    # Change the metric endpoint to the New Relic EU region
+    # metric-ingest-uri = https://metric-api.eu.newrelic.com/metric/v1
+
+    # Change the trace endpoint to the New Relic EU region
+    # span-ingest-uri = https://trace-api.eu.newrelic.com/trace/v1
 }
 {% endcode_block %}
 
@@ -30,6 +36,11 @@ If you can't use an environment variable, you can replace the above with the act
 Note: This is less secure and additional precautions must be taken (like considering file permissions and excluding from source control).
 
 ## Configuration
+The following configuration options are available to add to the `kamon.newrelic` configuration block.
+
+### Override Endpoints
+- `metric-ingest-uri`: By default, metrics are sent to the New Relic US region endpoint. You can change the endpoint to send metrics to New Relic's EU region. See [API endpoints for EU region accounts].
+- `span-ingest-uri`: By default, spans are sent to the New Relic US region endpoint. You can change the endpoint to send spans to an Infinite Tracing trace observer endpoint or to New Relic's EU region. See [Infinite Tracing] and [API endpoints for EU region accounts].  
 
 ### Disable tracing
 
@@ -54,3 +65,7 @@ To disable tracing, simply comment out `span-metrics` for the appropriate module
 [New Relic One distributed tracing]: https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/ui-data/additional-distributed-tracing-features-new-relic-one
 
 [New Relic One dashboards]: https://docs.newrelic.com/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards
+
+[API endpoints for EU region accounts]: https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers#endpoints
+
+[Infinite Tracing]: https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/enable-configure/integrations-enable-distributed-tracing


### PR DESCRIPTION
Includes the configuration options to override the metric and trace API URIs to allow sending metrics and traces to the New Relic EU region and traces to the NR Infinite tracing trace observer.