### PR TITLE
(fix) Support old /get-started URL

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -401,11 +401,17 @@ function bootOnboarding() {
     $("#onboarding-modal").modal("show")
   })
   window.addEventListener("message", function (tag) {
-    if (tag.data === "complete") {
-      window.open("https://apm.kamon.io", "_blank")
+    if (tag.origin.includes("apm.kamon.io")) {
+      if (tag.data === "complete") {
+        window.open("https://apm.kamon.io", "_blank")
+      }
+      $("#onboarding-modal").modal("hide")
     }
-    $("#onboarding-modal").modal("hide")
   })
+
+  if (window.location.hash === "#get-started") {
+    $("#onboarding-modal").modal("show")
+  }
 }
 
 $(document).ready(function() {

--- a/get-started.html
+++ b/get-started.html
@@ -1,0 +1,6 @@
+---
+layout: default
+title: 'Get started with Kamon'
+description: 'Support old getting started URL'
+redirect_to: /#get-started
+---


### PR DESCRIPTION
Add a redirect + JS hook to support the old get started URL.
Simply redirect to homepage with open APM modal.