### PR TITLE
(fix) Revert inline & minor docs tweaks

### DIFF
--- a/_includes/common.scss
+++ b/_includes/common.scss
@@ -1,1 +1,0 @@
-@import '../_sass/common';

--- a/_includes/includes-head.html
+++ b/_includes/includes-head.html
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="/assets/css/common.css">
+
 {% if page.custom_css %}
   {% for stylesheet in page.custom_css %}
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ stylesheet }}.css">
@@ -27,14 +29,6 @@
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/assets/favicon/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">
-
-{% capture styles %}
-{% include common.scss %}
-{% endcapture %}
-
-<style>
-{{ styles | scssify }}
-</style>
 
 <!--[if lt IE 9]>
   <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>

--- a/_includes/includes-tail.html
+++ b/_includes/includes-tail.html
@@ -1,5 +1,8 @@
-<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-<script src="/assets/js/jquery.min.js" ></script>
-<script src="/assets/js/popper.min.js" ></script>
-<script src="/assets/js/bootstrap.min.js" ></script>
-<script src="/assets/js/common.js" ></script>
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="/assets/js/jquery.min.js" ></script>
+    <script src="/assets/js/popper.min.js" ></script>
+    <script src="/assets/js/bootstrap.min.js" ></script>
+    <script src="/assets/js/common.js" ></script>
+    
+    
+    <!-- <script src="/assets/js/prism.js"></script> -->

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -181,5 +181,6 @@ layout: default
   </div>
 </div>
 
+<script src="/assets/js/jquery.min.js" async></script>
 <script src="/assets/js/prism.js" async></script>
 <script src="/assets/js/docs.js" async></script>

--- a/_sass/layouts/_docs.scss
+++ b/_sass/layouts/_docs.scss
@@ -55,7 +55,7 @@ body.has-notification {
   }
 
   .sticky-docs-navbar {
-    top: calc(57px + 52px + $notification-bar-height + 3rem);
+    top: calc(57px + 52px + #{$notification-bar-height} + 3rem);
   }
 }
 

--- a/assets/css/common.scss
+++ b/assets/css/common.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@import 'common';


### PR DESCRIPTION
* Revert the inlining of the css, it breaks things and doesn't seem to help much
* Correct interpolation of variable in calc in SCSS file
* Make sure jquery boots before docs.js, since otherwise the JS boot fails on that page