### PR TITLE
(feat) APM link parameter support

### DIFF
--- a/apm.html
+++ b/apm.html
@@ -29,7 +29,7 @@ description: 'Easy to use application performance monitoring tool to monitor and
       <p class="lead">
         Go from clueless to solving issues in a few clicks.
       </p>
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button" href="#">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button" data-solution="KamonAPM" href="#">
         Start Monitoring Free
       </a>
       <h6 class="text-light text-center text-sm-left mt-2">

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -23,8 +23,13 @@ function showOnboardingModal() {
   const width = Math.min(window.innerWidth, 1200)
   const height = Math.max(window.innerHeight, 800)
 
+  const solution = $(this).data("solution")
+  const url = solution != null
+    ? `https://apm.kamon.io/onboarding?external=yes&solution=${solution}`
+    : "https://apm.kamon.io/onboarding?external=yes"
+
   $("#onboarding-iframe").attr("width", width).attr("height", height)
-  $("#onboarding-iframe").attr("src", "https://apm.kamon.io/onboarding?external=yes")
+  $("#onboarding-iframe").attr("src", url)
   $("#onboarding-modal").modal("show")
 }
 

--- a/docs/latest/guides/installation/akka-http.md
+++ b/docs/latest/guides/installation/akka-http.md
@@ -71,7 +71,7 @@ kamon {
 }
 {% endcode_block %}
 
-You can copy your API key directly from [Kamon APM](https://apm.kamon.io/api-keys){:target="_blank" rel="noopener"}.
+You can copy your API key directly from [Kamon APM](https://apm.kamon.io?envinfo=show){:target="_blank" rel="noopener"}.
 
 
 Verifying the Installation

--- a/docs/latest/guides/installation/lagom-framework.md
+++ b/docs/latest/guides/installation/lagom-framework.md
@@ -66,7 +66,7 @@ kamon {
 }
 {% endcode_block %}
 
-You can copy your API key directly from [Kamon APM](https://apm.kamon.io/api-keys){:target="_blank" rel="noopener"}.
+You can copy your API key directly from [Kamon APM](https://apm.kamon.io/?envinfo=show){:target="_blank" rel="noopener"}.
 
 
 

--- a/docs/latest/guides/installation/play-framework.md
+++ b/docs/latest/guides/installation/play-framework.md
@@ -62,7 +62,7 @@ kamon {
 }
 {% endcode_block %}
 
-You can copy your API key directly from [Kamon APM](https://apm.kamon.io/api-keys){:target="_blank" rel="noopener"}.
+You can copy your API key directly from [Kamon APM](https://apm.kamon.io?envinfo=show){:target="_blank" rel="noopener"}.
 
 
 


### PR DESCRIPTION
* Direct API key links to landing page + modal with env info, instead of
deprecated API keys page
* Add support for specifying an already selected solution for APM via
`solution` query parameter. Add an example where it's APM on the Kamon
APM page button. We can later do this contextually elsewhere.