### PR TITLE
Submit custom onboarding events to Google Analytics

### DIFF
--- a/_includes/includes-head.html
+++ b/_includes/includes-head.html
@@ -37,7 +37,7 @@
 
 <script>
   var host = window.location.hostname;
-  if(host != "localhost") {
+  if(!["localhost", "0.0.0.0"].includes(host)) {
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/_includes/includes-head.html
+++ b/_includes/includes-head.html
@@ -37,7 +37,7 @@
 
 <script>
   var host = window.location.hostname;
-  if(!["localhost", "0.0.0.0"].includes(host)) {
+  if(["localhost", "0.0.0.0"].indexOf(host) === -1) {
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/_includes/onboarding-modal.html
+++ b/_includes/onboarding-modal.html
@@ -6,5 +6,6 @@
         class="onboarding-iframe"
         allow="clipboard-read; clipboard-write;"
       ></iframe>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Send custom events to Google Analytics (via GTM) for 3 onboarding events:

1. onboarding_start (when the onboarding popup opens, either by cta click or url hash)
2. onboarding_choose_integration (when user selects integration type while onboarding)
3. onboarding_signup (when user signs up while onboarding)

Also:
- fix check for disabling gtm when running locally (not sure why we had localhost so left it just in case?)
- automatically show localhost or remote apm onboarding iframe depending on host