### PR TITLE
(feat) Add outdated docs warning

### DIFF
--- a/_includes/outdated-docs-notice.html
+++ b/_includes/outdated-docs-notice.html
@@ -1,0 +1,5 @@
+{% alert warning %}
+  <p>
+    You are viewing documentation for an outdated version. Do you wish to see documentation for the <a href="{{include.link}}">latest version</a>?
+  </p>
+{% endalert %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -9,6 +9,7 @@ layout: default
 {% assign all_sections = 'guides, core, instrumentation, reporters' | split: ', ' %}
 {% assign version_prefix = page.path | split: '/' | slice: 0, 2 | join: '/' %}
 {% assign current_pretty_path = page.url | remove_first: '.html' %}
+{% assign latest_version_link = page.url | replace: current_version, "latest" %}
 
 <div class="d-none d-lg-block bg-lightest docs-header">
   <div class="container">
@@ -176,6 +177,9 @@ layout: default
     {% endif %}
 
     <div id="docs-content" class="docs-container {% if sidebar_data %}col-12 col-lg-9 pl-lg-5 pt-5 pt-lg-0 {% else %}col-12{% endif %}">
+      {% if current_version == 'v1' %}
+        {% include outdated-docs-notice.html link=latest_version_link %}
+      {% endif %}
       {% include anchor_headings.html html=content anchorBody="#" anchorClass="heading-anchor" %}
     </div>
   </div>


### PR DESCRIPTION
Add a warning on top of the documentation content if you're looking at
V1 docs. It will include a notice and a link to the latest version of
the docs. In cases where the exact docs do not exist, this will land the
user on the more generic topic page.