### PR TITLE
(chore) Update GAPI event types

### DIFF
--- a/_sass/_onboarding.scss
+++ b/_sass/_onboarding.scss
@@ -11,7 +11,7 @@
     right: unset;
     bottom: unset;
     left: unset;
-    max-width: 90vw;
+    max-width: 1200px;
     max-height: 90vh;
   }
 }

--- a/_sass/_onboarding.scss
+++ b/_sass/_onboarding.scss
@@ -24,6 +24,8 @@
 
 .onboarding-iframe {
   width: 100%;
+  border: none;
+  border-radius: 8px;
 
   @media (min-width: 620px) {
     max-height: 90vh;

--- a/_sass/_onboarding.scss
+++ b/_sass/_onboarding.scss
@@ -17,6 +17,9 @@
 }
 
 .modal-content {
+  border-radius: 8px;
+  border: none;
+
   @media (min-width: 620px) {
     max-height: 90vh;
   }

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -10,9 +10,9 @@ function getPageViewForGAEvent(eventCategory, eventAction) {
     case GAEvents.onboarding_start:
       return ({ title: "Onboarding Started", path: "onboarding/start/" })
     case GAEvents.onboarding_choose_integration:
-      return { title: `Choose integration`, path: `onboarding/choose-integration/${eventAction.toLowerCase()}/`}
+      return { title: `Choose Integration ${eventAction}`, path: `onboarding/choose-integration/${eventAction.toLowerCase()}/`}
     case GAEvents.onboarding_choose_project_type:
-      return { title: `Choose project type`, path: `onboarding/choose-project-type/${eventAction.toLowerCase()}/`}
+      return { title: `Choose Project Type ${eventAction}`, path: `onboarding/choose-project-type/${eventAction.toLowerCase()}/`}
     case GAEvents.onboarding_signup:
       return { title: "Onboarding Signed up with APM", path: "onboarding/signed-up/" }
   }

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,15 +1,18 @@
 const GAEvents = {
   onboarding_start: "onboarding_start",
   onboarding_choose_integration: "onboarding_choose_integration",
+  onboarding_choose_project_type: "onboarding_choose_project_type",
   onboarding_signup: "onboarding_signup",
 }
 
 function getPageViewForGAEvent(eventCategory, eventAction) {
   switch (eventCategory) {
     case GAEvents.onboarding_start:
-      return ({ title: "Onboarding Solution Selection", path: "onboarding/solution-selection/" })
+      return ({ title: "Onboarding Started", path: "onboarding/start/" })
     case GAEvents.onboarding_choose_integration:
-      return { title: `Onboarding Started with ${eventAction}`, path: `onboarding/started-with/${eventAction.toLowerCase()}/`}
+      return { title: `Choose integration`, path: `onboarding/choose-integration/${eventAction.toLowerCase()}/`}
+    case GAEvents.onboarding_choose_project_type:
+      return { title: `Choose project type`, path: `onboarding/choose-project-type/${eventAction.toLowerCase()}/`}
     case GAEvents.onboarding_signup:
       return { title: "Onboarding Signed up with APM", path: "onboarding/signed-up/" }
   }

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -31,7 +31,7 @@ function sendGoogleAnalyticsEvent(eventCategory, eventAction) {
   if (dataLayer != null) {
     dataLayer.push({
       "event": eventCategory,
-      "customEventAction": eventAction.toLowerCase()
+      "customEventAction": eventAction ? eventAction.toLowerCase() : undefined
     })
     const pageView = getPageViewForGAEvent(eventCategory, eventAction)
     if (pageView != null) {

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -99,9 +99,11 @@ function bootOnboarding() {
       if (tag.data === "complete") {
         window.open(baseAPMUrl, "_blank")
         $("#onboarding-modal").modal("hide")
+        $("#onboarding-iframe").attr("src", undefined)
       }
       if (tag.data === "close") {
         $("#onboarding-modal").modal("hide")
+        $("#onboarding-iframe").attr("src", undefined)
       }
     }
   })

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -19,7 +19,7 @@ function getPageViewForGAEvent(eventCategory, eventAction) {
 }
 
 function getBaseAPMUrl() {
-  return window.location.hostname === "0.0.0.0"
+  return window.location.hostname === "0.0.0.0" || window.location.hostname === "localhost"
     ? "http://localhost:9999"
     : "https://apm.kamon.io"
 }


### PR DESCRIPTION
Change Google API event types to match new quick onboarding

I'll need a sanity check on this, but also assistance setting up the new and improved events.