### PR TITLE
Start the DocSearch integration

### DIFF
--- a/_includes/includes-head.html
+++ b/_includes/includes-head.html
@@ -10,6 +10,12 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/layouts/{{ page.layout }}.css">
 {% endif %}
 
+{% if page.layout == "docs" %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" /> 
+{% endif %}
+
+
+
 <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous"> -->
 <link rel="apple-touch-icon" sizes="57x57" href="/assets/favicon/apple-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="/assets/favicon/apple-icon-60x60.png">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -97,7 +97,10 @@ layout: default
 
       {% if documentation %}
       <div id="docs-sidebar" class="d-none d-lg-block col-3 p-0 pr-3 docs-sidebar-nav d-none d-lg-block sticky-docs-navbar">
-        <input id="docSearch" type="text">
+        <div class="doc-search-container">
+          <input id="docSearch" type="text" placeholder="Search the Docs...">
+          <img class="doc-search-icon" src="/assets/img/icons/search-icon.svg" />
+        </div>
         <ul>
           {% for section in documentation %}
           {% assign section_id = section.name | slugify %}
@@ -179,9 +182,12 @@ layout: default
 <script src="/assets/js/docs.js" defer></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
-apiKey: 'b8559453007fa5c62d8074697f3db5f5',
-indexName: 'kamon',
-inputSelector: '#docSearch',
-debug: false
+  apiKey: 'b8559453007fa5c62d8074697f3db5f5',
+  indexName: 'kamon',
+  inputSelector: '#docSearch',
+  debug: false,
+  algoliaOptions: {
+    hitsPerPage: 12,
+  },
 });
 </script> 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -96,7 +96,8 @@ layout: default
     <div class="row">
 
       {% if documentation %}
-      <div id="docs-sidebar" class="d-none d-lg-block col-3 p-0 pr-3 docs-sidebar-nav d-none d-lg-block sticky-docs-navbar docs-sidebar-scroll">
+      <div id="docs-sidebar" class="d-none d-lg-block col-3 p-0 pr-3 docs-sidebar-nav d-none d-lg-block sticky-docs-navbar">
+        <input id="docSearch" type="text">
         <ul>
           {% for section in documentation %}
           {% assign section_id = section.name | slugify %}
@@ -176,3 +177,11 @@ layout: default
 
 <script src="/assets/js/prism.js" defer></script>
 <script src="/assets/js/docs.js" defer></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: 'b8559453007fa5c62d8074697f3db5f5',
+indexName: 'kamon',
+inputSelector: '#docSearch',
+debug: false
+});
+</script> 

--- a/_sass/layouts/_docs.scss
+++ b/_sass/layouts/_docs.scss
@@ -101,7 +101,7 @@ body.has-notification {
       height: 40px;
       border-radius: 8px;
       outline: none;
-      padding: 8px 16px;
+      padding: 8px 16px 24px 16px;
       color: #8F90A6;
       font-size: 14px;
       line-height: 24px;

--- a/_sass/layouts/_docs.scss
+++ b/_sass/layouts/_docs.scss
@@ -70,16 +70,46 @@ body.has-notification {
 
 .docs-sidebar-nav, .docs-mobile-navigation-container {
   $sidebar-vertical-margin: 170px;
-  overflow: visible;
 
   background-color: $color-light-3;
-  max-height: calc(100vh - #{$sidebar-vertical-margin});
-  @include custom-scrollbar;
+  z-index: 1010;
+  
+  > ul {
+    max-height: calc(100vh - #{$sidebar-vertical-margin} - 40px - 24px);
+    @include custom-scrollbar;
+  }
 
-  #docSearch {
-    position: absolute;
-    width: 100%;
-    z-index: 999;
+  .doc-search-container {
+    position: relative;
+    padding-bottom: 24px;
+
+    .algolia-autocomplete {
+      width: 100%;
+    }
+
+    .doc-search-icon {
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      top: calc(20px - 9px);
+      right: 8px;
+    }
+
+    #docSearch {
+      width: 100%;
+      border: none;
+      height: 40px;
+      border-radius: 8px;
+      outline: none;
+      padding: 8px 16px;
+      color: #8F90A6;
+      font-size: 14px;
+      line-height: 24px;
+
+      &::placeholder {
+        opacity: 1;
+      }
+    }
   }
 
   // Sections are the top of the docs: Guides, Core, Instrumentation and so on.

--- a/_sass/layouts/_docs.scss
+++ b/_sass/layouts/_docs.scss
@@ -119,6 +119,7 @@ body.has-notification {
     color: $color-dark-3;
     font-weight: 500;
     font-size: 1rem;
+    -webkit-appearance: none;
 
     &.active {
       color: $color-shamrock-main;

--- a/_sass/layouts/_docs.scss
+++ b/_sass/layouts/_docs.scss
@@ -70,10 +70,17 @@ body.has-notification {
 
 .docs-sidebar-nav, .docs-mobile-navigation-container {
   $sidebar-vertical-margin: 170px;
+  overflow: visible;
 
   background-color: $color-light-3;
   max-height: calc(100vh - #{$sidebar-vertical-margin});
   @include custom-scrollbar;
+
+  #docSearch {
+    position: absolute;
+    width: 100%;
+    z-index: 999;
+  }
 
   // Sections are the top of the docs: Guides, Core, Instrumentation and so on.
   .docs-section {
@@ -194,6 +201,7 @@ body.has-notification {
 }
 
 .docs-container {
+  z-index: 1000;
   background-color: white;
   border-radius: 16px;
   line-height: 1.6rem;

--- a/docs/latest/guides/installation/akka-http.md
+++ b/docs/latest/guides/installation/akka-http.md
@@ -75,7 +75,7 @@ You can copy your API key directly from [Kamon APM](https://apm.kamon.io?envinfo
 
 
 Verifying the Installation
-==========================
+--------------------------
 
 Next time your application starts, Kamon should be up and running as well! Open [http://localhost:5266/](http://localhost:5266/){:target="_blank" rel="noopener"}
 in your browser and you'll find the Kamon Status Page. It should look like this:

--- a/docs/latest/guides/installation/lagom-framework.md
+++ b/docs/latest/guides/installation/lagom-framework.md
@@ -72,7 +72,7 @@ You can copy your API key directly from [Kamon APM](https://apm.kamon.io/?envinf
 
 
 Verifying the Installation
-==========================
+--------------------------
 
 Next time your application starts, Kamon should be up and running as well! Open [http://localhost:5266/](http://localhost:5266/){:target="_blank" rel="noopener"}
 in your browser and you'll find the Kamon Status Page. It should look like this:

--- a/docs/latest/guides/installation/play-framework.md
+++ b/docs/latest/guides/installation/play-framework.md
@@ -67,7 +67,7 @@ You can copy your API key directly from [Kamon APM](https://apm.kamon.io?envinfo
 
 
 Verifying the Installation
-==========================
+--------------------------
 
 Next time your application starts, Kamon should be up and running as well! Open [http://localhost:5266/](http://localhost:5266/){:target="_blank" rel="noopener"}
 in your browser and you'll find the Kamon Status Page. It should look like this:


### PR DESCRIPTION
I had a quick attempt at integrating Algolia's DocSearch but need some CSS magic help here. Issues I found so far can be seen in this image:
![image](https://user-images.githubusercontent.com/1302854/114537815-ef3dfb00-9c52-11eb-8848-05db347873e2.png)
- The search bar stays behind the docs content.
- Some of the page results have no text in them. 

For the second problem, I'm under the impression that we have to tweak something on the [crawling configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/kamon.json) (there is a lot of interesting info regarding the config file format [here](https://docsearch.algolia.com/docs/config-file/)). So far, I think we must change the `start_urls` value and add `strip_chars` as shown here:

```
{
  "index_name": "kamon",
  "start_urls": [
    "https://kamon.io/docs/latest/overview/"
  ],
  "stop_urls": [],
  "selectors": {
    "lvl0": {
      "selector": "",
      "global": true,
      "default_value": "Documentation"
    },
    "lvl1": "#docs-content h1",
    "lvl2": "#docs-content h2",
    "lvl3": "#docs-content h3",
    "lvl4": "#docs-content h4",
    "lvl5": "#docs-content h5",
    "text": "#docs-content p, #docs-content li"
  },
  "strip_chars": "#",
  "conversation_id": [
    "1479974323"
  ],
  "nb_hits": 1524
}
```

But we might need to do something else with the selectors for the text to show up as expected. 
