### PR TITLE
(feat) Add support for small signup to APM modal

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -157,7 +157,7 @@
           </a>
         </li>
         <li class="navbar-item">
-          <a class="nav-link btn btn-primary onboarding-start-button" href="#"  data-url="signup?external=yes">
+          <a class="nav-link btn btn-primary onboarding-start-button" href="#" data-url="signup">
             Try Kamon APM
           </a>
         </li>

--- a/_sass/_onboarding.scss
+++ b/_sass/_onboarding.scss
@@ -14,13 +14,23 @@
     max-width: 1200px;
     max-height: 90vh;
   }
+
+  &.small-dialog {
+    @media (min-width: $md-start) {
+      max-width: 600px;
+      height: 100%;
+      max-height: unset;
+      display: flex;
+      align-items: center;
+    }
+  }
 }
 
 .modal-content {
   border-radius: 8px;
   border: none;
 
-  @media (min-width: 620px) {
+  @media (min-width: $md-start) {
     max-height: 90vh;
   }
 }
@@ -30,8 +40,16 @@
   border: none;
   border-radius: 8px;
 
-  @media (min-width: 620px) {
+  @media (min-width: $md-start) {
     max-height: 90vh;
+  }
+}
+
+.small-dialog {
+  .modal-content, .onboarding-iframe {
+    @media (min-width: $md-start) {
+      max-height: 764px;
+    }
   }
 }
  

--- a/apm.html
+++ b/apm.html
@@ -188,7 +188,7 @@ custom_css:
       </div>
       <div class="mb-5 text-light text-explainer d-flex align-items-end" style="height: 47px;">Up to 5 Services</div>
 
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4 py3" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4 py3" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <div class="mt-3 text-light text-center">
@@ -218,7 +218,7 @@ custom_css:
         <div class="mb-0 text-light text-explainer">Up to 10 Services</div>
       </div>
 
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4 py3" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4 py3" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <div class="mt-3 text-light text-center">
@@ -251,7 +251,7 @@ custom_css:
         <label class="mb-0 ml-1" for="teams-plan-service-number">Services</label>
       </div>
 
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4 py3" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4 py3" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <div class="mt-3 text-light text-center">

--- a/apm/pricing.html
+++ b/apm/pricing.html
@@ -50,7 +50,7 @@ custom_css:
           environment
         </li>
       </ul>
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <div class="mt-3 text-light">
@@ -97,7 +97,7 @@ custom_css:
           Pay a <b>Fixed Price</b> with <b>10 services</b><br/> included
         </li>
       </ul>
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <div class="mt-3 text-light">
@@ -150,7 +150,7 @@ custom_css:
           <b>Save 20%</b> and get additional<br/>retention with <b>annual billing</b>
         </li>
       </ul>
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-4" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <div class="mt-3 text-light">

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -47,19 +47,38 @@ function initScrollMainHeader() {
   }
 }
 
-function showOnboardingModal(externalUrl) {
-  const width = Math.min(window.innerWidth, 1200)
+/**
+ * 
+ * @param {string} externalUrl External path instead of /onboarding (no leading slash)
+ * @param {boolean} isSmall Should a smaller version of the modal with no extra graphics be shown
+ */
+function showOnboardingModal(externalUrl, isSmall) {
+  const width = Math.min(window.innerWidth, isSmall ? 600 : 1200)
   const height = Math.max(window.innerHeight, 800)
   const baseAPMUrl = getBaseAPMUrl()
   const solution = $(this).data("solution")
-  const extension = externalUrl != null
-    ? externalUrl
-    : solution != null
-      ? `onboarding?external=yes&solution=${solution}`
-      : `onboarding?external=yes`
-  const url = `${baseAPMUrl}/${extension}`
+  const extension = externalUrl != null ? externalUrl : "onboarding"
+  const queryParams = new URLSearchParams()
+  queryParams.set("external", "yes")
+  
+  if (solution != null) {
+    queryParams.set("solution", solution)
+  }
+
+  if (isSmall) {
+    queryParams.set("small", "true")
+  }
+
+  const url = `${baseAPMUrl}/${extension}?${queryParams.toString()}`
   $("#onboarding-iframe").attr("width", width).attr("height", height)
   $("#onboarding-iframe").attr("src", url)
+  
+  if (isSmall) {
+    $(".onboarding-modal-dialog").addClass("small-dialog")
+  } else {
+    $(".onboarding-modal-dialog").removeClass("small-dialog")
+  }
+
   $("#onboarding-modal").modal("show")
 }
 
@@ -67,7 +86,8 @@ function bootOnboarding() {
   $(".onboarding-start-button").on("click", function() {
     sendGoogleAnalyticsEvent(GAEvents.onboarding_start, "Via CTA")
     const url = $(this).data("url")
-    showOnboardingModal(url)
+    const isSmall = $(this).data("small") != null
+    showOnboardingModal(url, isSmall)
   })
 
   window.addEventListener("message", function (tag) {

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ custom_css:
         <br class="d-none d-md-inline">
         hurt your <b>microservices performance</b> in production
       </p>
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 py3 mr-3" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 py3 mr-3" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2 my-2" href="#">

--- a/solutions/monitoring-for-akka.html
+++ b/solutions/monitoring-for-akka.html
@@ -30,7 +30,7 @@ redirect_from:
           Akka microservices in a <b>fully managed solution</b>, starting <b>Free</b> with Kamon APM
         </p>
 
-        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 my-2 mr-3" href="#" data-url="signup?external=yes">
+        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 my-2 mr-3" href="#" data-url="signup">
           Try Kamon APM
         </a>
         <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">
@@ -228,7 +228,7 @@ redirect_from:
         </p>
       </div>
       <div class="col-12 text-center">
-        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-3" href="#" data-url="signup?external=yes">
+        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-3" href="#" data-url="signup">
           Try Kamon APM
         </a>
         <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">

--- a/solutions/monitoring-for-play-framework.html
+++ b/solutions/monitoring-for-play-framework.html
@@ -31,7 +31,7 @@ redirect_from:
           Play Framework in a <b>fully managed solution</b>, starting <b>Free</b> with Kamon APM
         </p>
 
-        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 my-2 mr-3" href="#" data-url="signup?external=yes">
+        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 my-2 mr-3" href="#" data-url="signup">
           Try Kamon APM
         </a>
         <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">
@@ -202,7 +202,7 @@ redirect_from:
         </p>
       </div>
       <div class="col-12 text-center">
-        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-3" href="#" data-url="signup?external=yes">
+        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-3" href="#" data-url="signup">
           Try Kamon APM
         </a>
         <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">

--- a/solutions/monitoring-for-spring-boot.html
+++ b/solutions/monitoring-for-spring-boot.html
@@ -30,7 +30,7 @@ redirect_from:
           in a <b>fully managed solution</b>, starting <b>Free</b> with Kamon APM
         </p>
 
-        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 my-2 mr-3" href="#" data-url="signup?external=yes">
+        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 my-2 mr-3" href="#" data-url="signup">
           Try Kamon APM
         </a>
         <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">
@@ -202,7 +202,7 @@ redirect_from:
         </p>
       </div>
       <div class="col-12 text-center">
-        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-3" href="#" data-url="signup?external=yes">
+        <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-3" href="#" data-url="signup">
           Try Kamon APM
         </a>
         <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">

--- a/telemetry.html
+++ b/telemetry.html
@@ -162,7 +162,7 @@ custom_css:
         It takes 3 minutes to start monitoring. Better now than <br class="d-none d-md-inline">
         after your next production incident
       </p>
-      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-2" href="#" data-url="signup?external=yes">
+      <a class="btn btn-lg btn-primary w-100-sm-down onboarding-start-button px-5 mr-3 my-2" href="#" data-url="signup">
         Try Kamon APM
       </a>
       <a class="btn btn-outline-secondary btn-lg w-100-sm-down onboarding-start-button px-5 py-2" href="#">


### PR DESCRIPTION
* Rewrite how URL is built to allow for easier configuration
* Now only the path itself needs to be passed in as external URL
* Add support for `data-small="true"` parameter to make a half-width
modal (to be used for signup)
* Update all external URLs affected
